### PR TITLE
CI/CD pipeline for tests and KB initialization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,22 @@ on:
     paths-ignore:
       - '**.md'
 
-# on: [push]
-
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install requirements
+        run: pip install -r requirements.txt 
+      - name: Run ontology tests
+        run: python3 project/kb_configuration/test_ontologies.py
+
   init-kb:
     runs-on: ubuntu-latest
     name: Initialize KB


### PR DESCRIPTION
### Changes
I've implemented a simple CI/CD pipeline that runs on GitHub hosted runners and produces the initialized knowledge base as an artifact.
The workflow runs as a result of each `push` on each branch, creating an action from which you can then download the artifact `KB` which contains both the newly initialized knowledge base and the file containing the static rules (for convenience).
You can also manually execute the action from the `Actions` tab on GitHub.
The pipeline also executes the unit tests under `kb_configuration/test_ontologies.py`

### Todo
- Integrate application deployment into the pipeline
- Remove knowledge base (`KB_new.pl`) from versioning